### PR TITLE
motd fixes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "go.testFlags": [
+    "-count=1"
+  ]
+}

--- a/formatting/colors/color.go
+++ b/formatting/colors/color.go
@@ -78,7 +78,7 @@ func Parse(value interface{}) Color {
 	case 'g', "g", "minecoin_gold", MinecoinGold:
 		return MinecoinGold
 	default:
-		return White
+		return Gray
 	}
 }
 

--- a/formatting/item.go
+++ b/formatting/item.go
@@ -12,13 +12,14 @@ import (
 // Item is a single formatting item that contains a color and any optional formatting controls
 type Item struct {
 	Text       string                 `json:"text"`
-	Color      colors.Color           `json:"color"`
+	Color      *colors.Color          `json:"color,omitempty"`
 	Decorators []decorators.Decorator `json:"decorators"`
 }
 
 // Raw returns the Minecraft encoding of the formatting (§ + formatting codes/color + text)
 func (i Item) Raw() (result string) {
-	if i.Color != colors.White {
+
+	if i.Color != nil {
 		result += i.Color.ToRaw()
 	}
 
@@ -42,8 +43,10 @@ func (i Item) Clean() string {
 func (i Item) HTML() string {
 	classes := make([]string, 0)
 
-	styles := map[string]string{
-		"color": i.Color.ToHex(),
+	styles := map[string]string{}
+
+	if i.Color != nil {
+		styles["color"] = i.Color.ToHex()
 	}
 
 	for _, decorator := range i.Decorators {

--- a/formatting/parser.go
+++ b/formatting/parser.go
@@ -161,7 +161,9 @@ func parseString(s string) ([]Item, error) {
 				if len(item.Text) == 0 && len(item.Decorators) == 0 {
 					item.Color = &color
 				} else {
-					tree = append(tree, item)
+					if len(item.Text) > 0 {
+						tree = append(tree, item)
+					}
 
 					item = Item{
 						Text:       "",
@@ -182,10 +184,9 @@ func parseString(s string) ([]Item, error) {
 					tree = append(tree, item)
 
 					item = Item{
-						Text: "",
-						Decorators: []decorators.Decorator{
-							decorator,
-						},
+						Text:       "",
+						Color:      item.Color,
+						Decorators: append(item.Decorators, decorator),
 					}
 				}
 

--- a/formatting/parser.go
+++ b/formatting/parser.go
@@ -137,17 +137,6 @@ func parseString(s string) ([]Item, error) {
 			break
 		}
 
-		if char == '\n' {
-			tree = append(tree, item)
-
-			item = Item{
-				Text:       "\n",
-				Decorators: make([]decorators.Decorator, 0),
-			}
-
-			continue
-		}
-
 		if char != '\u00A7' {
 			item.Text += string(char)
 

--- a/options/status.go
+++ b/options/status.go
@@ -2,30 +2,25 @@ package options
 
 import (
 	"time"
-
-	"github.com/mcstatus-io/mcutil/v2/formatting/colors"
 )
 
 // JavaStatus is the options used by the Status() function
 type JavaStatus struct {
-	EnableSRV        bool
-	Timeout          time.Duration
-	ProtocolVersion  int
-	DefaultMOTDColor colors.Color
+	EnableSRV       bool
+	Timeout         time.Duration
+	ProtocolVersion int
 }
 
 // JavaStatusLegacy is the options used by the StatusLegacy() function
 type JavaStatusLegacy struct {
-	EnableSRV        bool
-	Timeout          time.Duration
-	ProtocolVersion  int
-	DefaultMOTDColor colors.Color
+	EnableSRV       bool
+	Timeout         time.Duration
+	ProtocolVersion int
 }
 
 // BedrockStatus is the options used by the StatusBedrock() function
 type BedrockStatus struct {
-	EnableSRV        bool
-	Timeout          time.Duration
-	ClientGUID       int64
-	DefaultMOTDColor colors.Color
+	EnableSRV  bool
+	Timeout    time.Duration
+	ClientGUID int64
 }

--- a/status.go
+++ b/status.go
@@ -13,17 +13,15 @@ import (
 	"time"
 
 	"github.com/mcstatus-io/mcutil/v2/formatting"
-	"github.com/mcstatus-io/mcutil/v2/formatting/colors"
 	"github.com/mcstatus-io/mcutil/v2/options"
 	"github.com/mcstatus-io/mcutil/v2/response"
 )
 
 var (
 	defaultJavaStatusOptions = options.JavaStatus{
-		EnableSRV:        true,
-		Timeout:          time.Second * 5,
-		ProtocolVersion:  47,
-		DefaultMOTDColor: colors.White,
+		EnableSRV:       true,
+		Timeout:         time.Second * 5,
+		ProtocolVersion: 47,
 	}
 )
 
@@ -300,7 +298,7 @@ func readJavaStatusPongPacket(r io.Reader, payload int64) error {
 }
 
 func formatJavaStatusResponse(serverResponse rawJavaStatus, srvRecord *response.SRVRecord, latency time.Duration, opts options.JavaStatus) (*response.JavaStatus, error) {
-	motd, err := formatting.Parse(serverResponse.Description, opts.DefaultMOTDColor)
+	motd, err := formatting.Parse(serverResponse.Description)
 
 	if err != nil {
 		return nil, err

--- a/status_bedrock.go
+++ b/status_bedrock.go
@@ -15,17 +15,15 @@ import (
 	"time"
 
 	"github.com/mcstatus-io/mcutil/v2/formatting"
-	"github.com/mcstatus-io/mcutil/v2/formatting/colors"
 	"github.com/mcstatus-io/mcutil/v2/options"
 	"github.com/mcstatus-io/mcutil/v2/response"
 )
 
 var (
 	defaultBedrockStatusOptions = options.BedrockStatus{
-		EnableSRV:        true,
-		Timeout:          time.Second * 5,
-		ClientGUID:       0,
-		DefaultMOTDColor: colors.White,
+		EnableSRV:  true,
+		Timeout:    time.Second * 5,
+		ClientGUID: 0,
 	}
 	bedrockMagic = []byte{0x00, 0xFF, 0xFF, 0x00, 0xFE, 0xFE, 0xFE, 0xFE, 0xFD, 0xFD, 0xFD, 0xFD, 0x12, 0x34, 0x56, 0x78}
 )
@@ -323,7 +321,7 @@ func getStatusBedrock(host string, port uint16, options ...options.BedrockStatus
 	}
 
 	if len(motd) > 0 {
-		parsedMOTD, err := formatting.Parse(motd, opts.DefaultMOTDColor)
+		parsedMOTD, err := formatting.Parse(motd)
 
 		if err != nil {
 			return nil, err

--- a/status_legacy.go
+++ b/status_legacy.go
@@ -12,16 +12,14 @@ import (
 	"unicode/utf16"
 
 	"github.com/mcstatus-io/mcutil/v2/formatting"
-	"github.com/mcstatus-io/mcutil/v2/formatting/colors"
 	"github.com/mcstatus-io/mcutil/v2/options"
 	"github.com/mcstatus-io/mcutil/v2/response"
 )
 
 var (
 	defaultJavaStatusLegacyOptions = options.JavaStatusLegacy{
-		EnableSRV:        true,
-		Timeout:          time.Second * 5,
-		DefaultMOTDColor: colors.White,
+		EnableSRV: true,
+		Timeout:   time.Second * 5,
 	}
 )
 
@@ -158,7 +156,7 @@ func getStatusLegacy(host string, port uint16, options ...options.JavaStatusLega
 				return nil, err
 			}
 
-			motd, err := formatting.Parse(split[3], opts.DefaultMOTDColor)
+			motd, err := formatting.Parse(split[3])
 
 			if err != nil {
 				return nil, err
@@ -200,7 +198,7 @@ func getStatusLegacy(host string, port uint16, options ...options.JavaStatusLega
 			return nil, fmt.Errorf("status: not enough information received (expected=3, received=%d)", len(split))
 		}
 
-		motd, err := formatting.Parse(split[0], opts.DefaultMOTDColor)
+		motd, err := formatting.Parse(split[0])
 
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
- Made `Item.Color` in `Result.Tree` optional. Moving responsibility of what the default color should be to the consumer  (maybe `color: #808080` should be set in the html?)
- Removed ability to specify default MOTD color. Using white as the fallback didn't really make sense to me since that isn't the default.
- Made so that newlines do not make a new `Item`. Colors/decorations are carried over after the newline.