### PR TITLE
Set status handshake protocol to -1

### DIFF
--- a/status.go
+++ b/status.go
@@ -20,7 +20,7 @@ var (
 	defaultJavaStatusOptions = options.JavaStatus{
 		EnableSRV:       true,
 		Timeout:         time.Second * 5,
-		ProtocolVersion: 47,
+		ProtocolVersion: -1,
 	}
 )
 


### PR DESCRIPTION
This pull request changes the default Java handshake protocol from 47 to -1. When using 47, some servers might not respond as expected and will appear offline instead of online. Using -1 instead, as documented in the link below, the servers will appear online again. An example is `play . ninden . net` (remove spaces). 

See https://wiki.vg/Server_List_Ping#Handshake:
> If the client is pinging to determine what version to use, by convention -1 should be set.

This same change was recently made in the _popular_ PHP pinger Minecraft-Query ([see commit](https://github.com/xPaw/PHP-Minecraft-Query/commit/199b3195aada049f1ebd51d662cfc4b6a2b8f628)).